### PR TITLE
Correct colours for seamless switch betwen themes

### DIFF
--- a/themes/Pitaya smoothie-color-theme-noitalic.json
+++ b/themes/Pitaya smoothie-color-theme-noitalic.json
@@ -390,7 +390,7 @@
 				"storage.type.function.arrow"
 			],
 			"settings": {
-				"foreground": "#FF96B7"
+				"foreground": "#F26196"
 			}
 		},
 		{

--- a/themes/Pitaya smoothie-color-theme.json
+++ b/themes/Pitaya smoothie-color-theme.json
@@ -339,7 +339,7 @@
 				"variable.other.constant"
 			],
 			"settings": {
-				"foreground": "#7998F2"
+				"foreground": "#C4A2F5"
 			}
 		},
 		{


### PR DESCRIPTION
Fixes #6 

**No Italics theme**
* Fixed shade of pink that applies to JavaScript arrow functions, `async` keywords and import curly braces to match original theme.
  * Changed from `#FF96B7` to the correct `#F26196`

**Original theme**
* Fixed shade of purple in JavaScript const variable names to match No Italics theme.
  * Changed from `#7998F2` to the correct `#C4A2F5`